### PR TITLE
qcom_target: Commonize UM target HALs

### DIFF
--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -28,7 +28,7 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
     B_FAMILY := msm8226 msm8610 msm8974
     B64_FAMILY := msm8992 msm8994
     BR_FAMILY := msm8909 msm8916
-    UM_FAMILY := msm8937 msm8953
+    UM_FAMILY := msm8937 msm8953 8996
 
     BOARD_USES_ADRENO := true
 
@@ -69,7 +69,7 @@ ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
     else
     ifeq ($(call is-board-platform-in-list, $(UM_FAMILY)),true)
         MSM_VIDC_TARGET_LIST := $(UM_FAMILY)
-        QCOM_HARDWARE_VARIANT := msm8937
+        QCOM_HARDWARE_VARIANT := msm8996
     else
         MSM_VIDC_TARGET_LIST := $(TARGET_BOARD_PLATFORM)
         QCOM_HARDWARE_VARIANT := $(TARGET_BOARD_PLATFORM)


### PR DESCRIPTION
* Use msm8996 HAL for 8953 & 8937 since they share the exact same
  git history sha1 in all 7.0+ released tags.